### PR TITLE
First draft of async version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssh"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -20,3 +20,7 @@ maintenance = { status = "experimental" }
 [dependencies]
 tempfile = "3.1.0"
 shellwords = "1"
+tokio = { version = "0.2", features = [ "process", "io-util" ] }
+
+[dev-dependencies]
+tokio = { version = "0.2", features = [ "full" ] }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,6 +112,7 @@ jobs:
  - template: coverage.yml@templates
    parameters:
      token: $(CODECOV_TOKEN_SECRET)
+     args: "--forward"
      services:
        opensshtest: openssh
      setup:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,14 +63,14 @@ jobs:
  # This represents the minimum Rust version supported.
  # Tests are not run as tests may require newer versions of rust.
  - job: msrv
-   displayName: "Minimum supported Rust version: 1.36.0"
+   displayName: "Minimum supported Rust version: 1.40.0"
    dependsOn: []
    pool:
      vmImage: ubuntu-latest
    steps:
      - template: install-rust.yml@templates
        parameters:
-         rust: 1.36.0
+         rust: 1.40.0 # bytes requires 1.39, mem::take requires 1.40
      - script: cargo check
        displayName: cargo check
      - script: cargo check --no-default-features

--- a/examples/tsp.rs
+++ b/examples/tsp.rs
@@ -1,17 +1,19 @@
 use openssh::*;
 
-fn main() {
-    let session =
-        Session::connect("ssh://jon@ssh.thesquareplanet.com:222", KnownHosts::Strict).unwrap();
+#[tokio::main]
+async fn main() {
+    let session = Session::connect("ssh://jon@ssh.thesquareplanet.com:222", KnownHosts::Strict)
+        .await
+        .unwrap();
 
-    let ls = session.command("ls").output().unwrap();
+    let ls = session.command("ls").output().await.unwrap();
     eprintln!(
         "{}",
         String::from_utf8(ls.stdout).expect("server output was not valid UTF-8")
     );
 
-    let whoami = session.command("whoami").output().unwrap();
+    let whoami = session.command("whoami").output().await.unwrap();
     assert_eq!(whoami.stdout, b"jon\n");
 
-    session.close().unwrap();
+    session.close().await.unwrap();
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,8 @@
 use super::{Error, Session};
-use std::io::prelude::*;
-use std::process::{self, Stdio};
+use std::process::Stdio;
 use tempfile::Builder;
+use tokio::io::AsyncReadExt;
+use tokio::process;
 
 /// Build a [`Session`] with options.
 #[derive(Debug, Clone)]
@@ -77,7 +78,7 @@ impl SessionBuilder {
     /// If connecting requires interactive authentication based on `STDIN` (such as reading a
     /// password), the connection will fail. Consider setting up keypair-based authentication
     /// instead.
-    pub fn connect<S: AsRef<str>>(&self, destination: S) -> Result<Session, Error> {
+    pub async fn connect<S: AsRef<str>>(&self, destination: S) -> Result<Session, Error> {
         let mut destination = destination.as_ref();
 
         // the "new" ssh://user@host:port form is not supported by all versions of ssh, so we
@@ -102,7 +103,7 @@ impl SessionBuilder {
         }
 
         if user.is_none() && port.is_none() {
-            return self.just_connect(destination);
+            return self.just_connect(destination).await;
         }
 
         let mut with_overrides = self.clone();
@@ -114,10 +115,10 @@ impl SessionBuilder {
             with_overrides.port(port);
         }
 
-        with_overrides.just_connect(destination)
+        with_overrides.just_connect(destination).await
     }
 
-    pub(crate) fn just_connect<S: AsRef<str>>(&self, host: S) -> Result<Session, Error> {
+    pub(crate) async fn just_connect<S: AsRef<str>>(&self, host: S) -> Result<Session, Error> {
         let destination = host.as_ref();
         let dir = Builder::new()
             .prefix(".ssh-connection")
@@ -165,26 +166,21 @@ impl SessionBuilder {
         // if the call _didn't_ error, then the backgrounded ssh client will still hold onto those
         // handles, and it's still running, so those reads will hang indefinitely.
         let mut child = init.spawn().map_err(Error::Connect)?;
-        let status = child.wait().map_err(Error::Connect)?;
+        let stdout = child.stdout.take().unwrap();
+        let mut stderr = child.stderr.take().unwrap();
+        let status = child.await.map_err(Error::Connect)?;
 
-        if let Some(255) = status.code() {
-            // this is the ssh command's way of telling us that the connection failed
-            let mut stderr = String::new();
-            child
-                .stderr
-                .as_mut()
-                .unwrap()
-                .read_to_string(&mut stderr)
-                .unwrap();
-
-            return Err(Error::interpret_ssh_error(&stderr));
+        if !status.success() {
+            let mut err = String::new();
+            stderr.read_to_string(&mut err).await.unwrap();
+            return Err(Error::interpret_ssh_error(&err));
         }
 
         Ok(Session {
             ctl: dir,
             addr: String::from(destination),
             terminated: false,
-            master: std::sync::Mutex::new(Some(child)),
+            master: std::sync::Mutex::new(Some((stdout, stderr))),
         })
     }
 }

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -392,6 +392,7 @@ async fn broken_connection() {
         .output()
         .await
         .unwrap_err();
+    eprintln!("{:?}", killed);
     assert!(matches!(killed, Error::Disconnected));
 
     // this fails because the master connection is gone
@@ -401,6 +402,7 @@ async fn broken_connection() {
         .output()
         .await
         .unwrap_err();
+    eprintln!("{:?}", failed);
     assert!(matches!(failed, Error::Disconnected));
 
     // so does this


### PR DESCRIPTION
Note that `try_wait` had to go, and `wait` has to consume `self`, since
`tokio::process` does not support those. That will change in the next
tokio release, but for now, I've just commented out the code that we'll
bring back when we can.