### PR TITLE
Docs

### DIFF
--- a/src/child.rs
+++ b/src/child.rs
@@ -6,8 +6,8 @@ use tokio::process;
 /// Representation of a running or exited remote child process.
 ///
 /// This structure is used to represent and manage remote child processes. A remote child process
-/// is created via the [`Command`](crate::Command) struct through [`Session::command`], which configures the
-/// spawning process and can itself be constructed using a builder-style interface.
+/// is created via the [`Command`](crate::Command) struct through [`Session::command`], which
+/// configures the spawning process and can itself be constructed using a builder-style interface.
 ///
 /// Calling [`wait`](RemoteChild::wait) (or other functions that wrap around it) will make the
 /// parent process wait until the child has actually exited before continuing.
@@ -20,13 +20,15 @@ use tokio::process;
 /// As a result, `RemoteChild` cannot expose `stdin`, `stdout`, and `stderr` as fields for
 /// split-borrows like [`std::process::Child`] does. Instead, it exposes
 /// [`stdin`](RemoteChild::stdin), [`stdout`](RemoteChild::stdout),
-/// and [`stderr`](RemoteChild::stderr).
-/// Callers can call `.take()` to get the same effect as a split borrow, to use multiple streams concurrently:
+/// and [`stderr`](RemoteChild::stderr) as methods.  Callers can call `.take()` to get the same
+/// effect as a split borrow, to use multiple streams concurrently:
 /// ```rust,no_run
+/// # async fn foo() {
 /// # let child: openssh::RemoteChild<'static> = unimplemented!();
 /// let stdin = child.stdin().take().unwrap();
 /// let stdout = child.stdout().take().unwrap();
-/// tokio::io::copy(&mut stdout, &mut stdin); //.await
+/// tokio::io::copy(&mut stdout, &mut stdin).await;
+/// # }
 /// ```
 #[derive(Debug)]
 pub struct RemoteChild<'s> {

--- a/src/child.rs
+++ b/src/child.rs
@@ -20,8 +20,11 @@ use tokio::process;
 /// As a result, `RemoteChild` cannot expose `stdin`, `stdout`, and `stderr` as fields for
 /// split-borrows like [`std::process::Child`] does. Instead, it exposes
 /// [`stdin`](RemoteChild::stdin), [`stdout`](RemoteChild::stdout),
-/// and [`stderr`](RemoteChild::stderr) as methods.  Callers can call `.take()` to get the same
-/// effect as a split borrow, to use multiple streams concurrently:
+/// and [`stderr`](RemoteChild::stderr) as methods. Callers can call `.take()` to get the same
+/// effect as a split borrow and use multiple streams concurrently. Note that for the streams to be
+/// available,`Stdio::piped()` should be passed to the corresponding method on
+/// [`Command`](crate::Command).
+///
 /// ```rust,no_run
 /// # async fn foo() {
 /// # let child: openssh::RemoteChild<'static> = unimplemented!();

--- a/src/child.rs
+++ b/src/child.rs
@@ -6,7 +6,7 @@ use tokio::process;
 /// Representation of a running or exited remote child process.
 ///
 /// This structure is used to represent and manage remote child processes. A remote child process
-/// is created via the [`Command`] struct through [`Session::command`], which configures the
+/// is created via the [`Command`](crate::Command) struct through [`Session::command`], which configures the
 /// spawning process and can itself be constructed using a builder-style interface.
 ///
 /// Calling [`wait`](RemoteChild::wait) (or other functions that wrap around it) will make the
@@ -18,9 +18,10 @@ use tokio::process;
 /// yourself by executing a remote command like `pkill` to kill it on the remote side.
 ///
 /// As a result, `RemoteChild` cannot expose `stdin`, `stdout`, and `stderr` as fields for
-/// split-borrows like [`std::process::Child`] does. Instead, it exposes [`RemoteChild::stdin`],
-/// [`RemoteChild::stdout`], and [`RemoteChild::stderr`]. Callers can call `.take()` to get the
-/// same effect as a split borrow, to use multiple streams concurrently:
+/// split-borrows like [`std::process::Child`] does. Instead, it exposes
+/// [`stdin`](RemoteChild::stdin), [`stdout`](RemoteChild::stdout),
+/// and [`stderr`](RemoteChild::stderr).
+/// Callers can call `.take()` to get the same effect as a split borrow, to use multiple streams concurrently:
 /// ```rust,no_run
 /// # let child: openssh::RemoteChild<'static> = unimplemented!();
 /// let stdin = child.stdin().take().unwrap();

--- a/src/command.rs
+++ b/src/command.rs
@@ -83,7 +83,7 @@ impl<'s> Command<'s> {
     /// # ; }
     /// ```
     ///
-    /// To pass multiple arguments see [`args`].
+    /// To pass multiple arguments see [`args`](Command::args).
     ///
     ///   [`shellwords`]: https://crates.io/crates/shellwords
     pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
@@ -99,7 +99,7 @@ impl<'s> Command<'s> {
     /// the remote host is running, we cannot prevent this, so consider escaping your arguments
     /// with something like [`shellwords`] as necessary.
     ///
-    /// To pass a single argument see [`arg`].
+    /// To pass a single argument see [`arg`](Command::arg).
     ///
     ///   [`shellwords`]: https://crates.io/crates/shellwords
     pub fn args<I, S>(&mut self, args: I) -> &mut Self

--- a/src/command.rs
+++ b/src/command.rs
@@ -10,8 +10,8 @@ use tokio::process;
 ///
 /// A default configuration can be generated using [`Session::command(program)`](Session::command),
 /// where `program` gives a path to the program to be executed. Additional builder methods allow
-/// the configuration to be changed (for example, by adding arguments) prior to spawning.
-/// The interface is almost identical to that of [`std::process::Command`].
+/// the configuration to be changed (for example, by adding arguments) prior to spawning.  The
+/// interface is almost identical to that of [`std::process::Command`].
 ///
 /// `Command` can be reused to spawn multiple remote processes. The builder methods change the
 /// command without needing to immediately spawn the process. Similarly, you can call builder

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
     /// The connection to the remote host was severed.
     ///
     /// Note that this is a best-effort error, and it _may_ instead signify that the remote process
-    /// exited with an error code of 255. You should call [`Session::check`] to verify if you get
+    /// exited with an error code of 255. You should call [`Session::check`](crate::Session::check) to verify if you get
     /// this error back.
     Disconnected,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,8 +15,8 @@ pub enum Error {
     /// The connection to the remote host was severed.
     ///
     /// Note that this is a best-effort error, and it _may_ instead signify that the remote process
-    /// exited with an error code of 255. You should call [`Session::check`](crate::Session::check) to verify if you get
-    /// this error back.
+    /// exited with an error code of 255. You should call [`Session::check`](crate::Session::check)
+    /// to verify if you get this error back.
     Disconnected,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@
 #![warn(
     missing_docs,
     missing_debug_implementations,
+    intra_doc_link_resolution_failure,
     rust_2018_idioms,
     unreachable_pub
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //! And finally, our commands never default to inheriting stdin/stdout/stderr, since we expect you
 //! are using this to automate things. Instead, unless otherwise noted, all I/O ports default to
-//! [`Stdio::null`].
+//! [`Stdio::null`](std::process::Stdio::null).
 //!
 //! # Authentication
 //!
@@ -111,7 +111,7 @@ pub use sftp::{Mode, RemoteFile, Sftp};
 /// You can use [`command`] to start a new command on the connected machine.
 ///
 /// When the `Session` is dropped, the connection to the remote host is severed, and any errors
-/// silently ignored. To disconnect and be alerted to errors, use [`close`].
+/// silently ignored. To disconnect and be alerted to errors, use [`close`](Session::close).
 #[derive(Debug)]
 pub struct Session {
     ctl: tempfile::TempDir,

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -80,11 +80,11 @@ impl<'s> Sftp<'s> {
     /// can also produce false positives, such as if you are checking whether you can write to a
     /// file on a read-only file system that you still have write permissions on.
     ///
-    /// Operations like [`read_from`](Sftp::read_from) and [`write_to`](Sftp::write_to) internally perform similar checking to this
-    /// method, so you do not need to call `can` before calling those methods. The checking
-    /// performed by `write_to` can also test its permissions by actually attemping to create the
-    /// remote file (since it is about to create one anyway), so its checking is more reliable than
-    /// what `can` can provide.
+    /// Operations like [`read_from`](Sftp::read_from) and [`write_to`](Sftp::write_to) internally
+    /// perform similar checking to this method, so you do not need to call `can` before calling
+    /// those methods. The checking performed by `write_to` can also test its permissions by
+    /// actually attemping to create the remote file (since it is about to create one anyway), so
+    /// its checking is more reliable than what `can` can provide.
     pub async fn can(
         &mut self,
         mode: Mode,
@@ -263,9 +263,9 @@ impl<'s> Sftp<'s> {
     ///
     /// If the remote file exists, it will be truncated. If it does not, it will be created.
     ///
-    /// Note that some errors may not propagate until you call [`close`](RemoteFile::close). This method internally
-    /// performs similar checks to [`can`](Sftp::can) though, so you should not need to call `can` before
-    /// calling this method.
+    /// Note that some errors may not propagate until you call [`close`](RemoteFile::close). This
+    /// method internally performs similar checks to [`can`](Sftp::can) though, so you should not
+    /// need to call `can` before calling this method.
     ///
     /// # Examples
     ///
@@ -316,10 +316,9 @@ impl<'s> Sftp<'s> {
     ///
     /// If the remote file exists, it will be appended to. If it does not, it will be created.
     ///
-    /// Note that some errors may not propagate until you call
-    /// [`close`](RemoteFile::close). This method internally
-    /// performs similar checks to [`can`](Sftp::can) though, so you should not need to call `can` before
-    /// calling this method.
+    /// Note that some errors may not propagate until you call [`close`](RemoteFile::close). This 
+    /// method internally performs similar checks to [`can`](Sftp::can) though, so you should not 
+    /// need to call `can` before calling this method.
     ///
     /// # Examples
     ///
@@ -369,9 +368,9 @@ impl<'s> Sftp<'s> {
 
     /// Open the remote file at `path` for reading.
     ///
-    /// Note that some errors may not propagate until you call [`close`](RemoteFile::close). This method internally
-    /// performs similar checks to [`can`](Sftp::can) though, so you should not need to call `can` before
-    /// calling this method.
+    /// Note that some errors may not propagate until you call [`close`](RemoteFile::close). This 
+    /// method internally performs similar checks to [`can`](Sftp::can) though, so you should not 
+    /// need to call `can` before calling this method.
     ///
     /// # Examples
     ///
@@ -423,7 +422,8 @@ impl<'s> Sftp<'s> {
 impl RemoteFile<'_> {
     /// Close the handle to the remote file.
     ///
-    /// If the remote file was opened for reading, this will also call [`flush`](AsyncWriteExt::flush).
+    /// If the remote file was opened for reading, this will also call 
+    /// [`flush`](AsyncWriteExt::flush).
     ///
     /// When you close the remote file, any errors on the remote end will also be propagated. This
     /// means that you could see errors about remote files not existing, or disks being full, only

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -47,13 +47,13 @@ impl Mode {
 /// Note that because we are operating against a remote host, errors may take a while to propagate.
 /// The various methods on `RemoteFile` will generally attempt to first check that the file you are
 /// trying to access can indeed be accessed in that way, but some errors may not become visible
-/// until you call [`close`](RemoteFile::close).
-/// In particular, the connection between you and the remote host may buffer bytes, so your
-/// write may report that some number of bytes have been successfully written, even though
-/// the remote disk is full. Or the file you are reading from may have been removed between when
-/// [`read_from`](Sftp::read_from) checks that it exists and when it actually tries to read the
-/// first byte. For that reason, you should **make sure to call [`close`](RemoteFile::close)**
-/// to observe any errors that may have occurred when operating on the remote file.
+/// until you call [`close`](RemoteFile::close).  In particular, the connection between you and the
+/// remote host may buffer bytes, so your write may report that some number of bytes have been
+/// successfully written, even though the remote disk is full. Or the file you are reading from may
+/// have been removed between when [`read_from`](Sftp::read_from) checks that it exists and when it
+/// actually tries to read the first byte. For that reason, you should **make sure to call
+/// [`close`](RemoteFile::close)** to observe any errors that may have occurred when operating on
+/// the remote file.
 #[derive(Debug)]
 pub struct RemoteFile<'s> {
     cat: super::RemoteChild<'s>,

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -316,8 +316,8 @@ impl<'s> Sftp<'s> {
     ///
     /// If the remote file exists, it will be appended to. If it does not, it will be created.
     ///
-    /// Note that some errors may not propagate until you call [`close`](RemoteFile::close). This 
-    /// method internally performs similar checks to [`can`](Sftp::can) though, so you should not 
+    /// Note that some errors may not propagate until you call [`close`](RemoteFile::close). This
+    /// method internally performs similar checks to [`can`](Sftp::can) though, so you should not
     /// need to call `can` before calling this method.
     ///
     /// # Examples
@@ -368,8 +368,8 @@ impl<'s> Sftp<'s> {
 
     /// Open the remote file at `path` for reading.
     ///
-    /// Note that some errors may not propagate until you call [`close`](RemoteFile::close). This 
-    /// method internally performs similar checks to [`can`](Sftp::can) though, so you should not 
+    /// Note that some errors may not propagate until you call [`close`](RemoteFile::close). This
+    /// method internally performs similar checks to [`can`](Sftp::can) though, so you should not
     /// need to call `can` before calling this method.
     ///
     /// # Examples
@@ -422,7 +422,7 @@ impl<'s> Sftp<'s> {
 impl RemoteFile<'_> {
     /// Close the handle to the remote file.
     ///
-    /// If the remote file was opened for reading, this will also call 
+    /// If the remote file was opened for reading, this will also call
     /// [`flush`](AsyncWriteExt::flush).
     ///
     /// When you close the remote file, any errors on the remote end will also be propagated. This


### PR DESCRIPTION
Make a note of the difference between getting stdin, stdout, and stderr via `std::process::Child` vs `RemoteChild`.
Also, a bunch of the doc links were broken, so I fixed them.