### PR TITLE
Escape arguments by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "experimental" }
 
 [dependencies]
 tempfile = "3.1.0"
-shellwords = "1"
+shell-escape = "0.1"
 tokio = { version = "0.2", features = [ "process", "io-util" ] }
 
 [dev-dependencies]

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,5 +1,6 @@
 use super::RemoteChild;
 use super::{Error, Session};
+use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::io;
 use std::process::Stdio;
@@ -60,11 +61,8 @@ impl<'s> Command<'s> {
 impl<'s> Command<'s> {
     /// Adds an argument to pass to the remote program.
     ///
-    /// The argument is passed as written to `ssh`, which will pass it again as an argument to the
-    /// remote shell. However, since the remote shell may do argument parsing, characters such as
-    /// spaces and `*` may be interpreted by the remote shell. Since we do not know what shell the
-    /// remote host is running, we cannot prevent this, so consider escaping your arguments with
-    /// something like [`shellwords`] as necessary.
+    /// Before it is passed to the remote host, `arg` is escaped so that special characters aren't
+    /// evaluated by the remote shell. If you do not want this behavior, use [`raw_arg`].
     ///
     /// Only one argument can be passed per use. So instead of:
     ///
@@ -84,25 +82,53 @@ impl<'s> Command<'s> {
     /// ```
     ///
     /// To pass multiple arguments see [`args`](Command::args).
+    pub fn arg<S: AsRef<str>>(&mut self, arg: S) -> &mut Self {
+        self.builder
+            .arg(&*shell_escape::unix::escape(Cow::Borrowed(arg.as_ref())));
+        self
+    }
+
+    /// Adds an argument to pass to the remote program.
     ///
-    ///   [`shellwords`]: https://crates.io/crates/shellwords
-    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+    /// Unlike [`arg`], this method does not shell-escape `arg`. The argument is passed as written
+    /// to `ssh`, which will pass it again as an argument to the remote shell. Since the remote
+    /// shell may do argument parsing, characters such as spaces and `*` may be interpreted by the
+    /// remote shell.
+    ///
+    /// To pass multiple unescaped arguments see [`raw_args`](Command::raw_args).
+    pub fn raw_arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
         self.builder.arg(arg);
         self
     }
 
     /// Adds multiple arguments to pass to the remote program.
     ///
-    /// The arguments are passed as written to `ssh`, which will pass them again as arguments to
-    /// the remote shell. However, since the remote shell may do argument parsing, characters such
-    /// as spaces and `*` may be interpreted by the remote shell. Since we do not know what shell
-    /// the remote host is running, we cannot prevent this, so consider escaping your arguments
-    /// with something like [`shellwords`] as necessary.
+    /// Before they are passed to the remote host, each argument in `args` is escaped so that
+    /// special characters aren't evaluated by the remote shell. If you do not want this behavior,
+    /// use [`raw_args`].
     ///
     /// To pass a single argument see [`arg`](Command::arg).
-    ///
-    ///   [`shellwords`]: https://crates.io/crates/shellwords
     pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        for arg in args {
+            self.builder
+                .arg(&*shell_escape::unix::escape(Cow::Borrowed(arg.as_ref())));
+        }
+        self
+    }
+
+    /// Adds multiple arguments to pass to the remote program.
+    ///
+    /// Unlike [`args`], this method does not shell-escape `args`. The arguments are passed as
+    /// written to `ssh`, which will pass them again as arguments to the remote shell. However,
+    /// since the remote shell may do argument parsing, characters such as spaces and `*` may be
+    /// interpreted by the remote shell.
+    ///
+    /// To pass a single argument see [`arg`](Command::arg).
+    pub fn raw_args<I, S>(&mut self, args: I) -> &mut Self
     where
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,

--- a/src/command.rs
+++ b/src/command.rs
@@ -83,8 +83,7 @@ impl<'s> Command<'s> {
     ///
     /// To pass multiple arguments see [`args`](Command::args).
     pub fn arg<S: AsRef<str>>(&mut self, arg: S) -> &mut Self {
-        self.builder
-            .arg(&*shell_escape::unix::escape(Cow::Borrowed(arg.as_ref())));
+        self.raw_arg(&*shell_escape::unix::escape(Cow::Borrowed(arg.as_ref())));
         self
     }
 
@@ -127,7 +126,7 @@ impl<'s> Command<'s> {
     /// since the remote shell may do argument parsing, characters such as spaces and `*` may be
     /// interpreted by the remote shell.
     ///
-    /// To pass a single argument see [`arg`](Command::arg).
+    /// To pass a single argument see [`raw_arg`](Command::raw_arg).
     pub fn raw_args<I, S>(&mut self, args: I) -> &mut Self
     where
         I: IntoIterator<Item = S>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,8 +294,7 @@ impl Session {
     ///   [`shell-escape`]: https://crates.io/crates/shell-escape
     pub fn shell<S: AsRef<str>>(&self, command: S) -> Command<'_> {
         let mut cmd = self.command("sh");
-        cmd.arg("-c")
-            .arg(shell_escape::unix::escape(Cow::Borrowed(command.as_ref())));
+        cmd.arg("-c").arg(command);
         cmd
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,9 @@
 //! Since that is _usually_ not what you expect to happen, `.arg("a b")` should pass a _single_
 //! argument with the value `a b`, `openssh` _escapes_ every argument (and the command itself) by
 //! default using [`shell-escape`]. This works well in most cases, but might run into issues when
-//! the remote shell has a different syntax than the shell `shell-escape` targets (bash). For
-//! example, Windows shells have different escaping syntax than bash does.
+//! the remote shell (generally the remote user's login shell) has a different syntax than the
+//! shell `shell-escape` targets (bash). For example, Windows shells have different escaping syntax
+//! than bash does.
 //!
 //! If this applies to you, you can use [`raw_arg`](Command::raw_arg),
 //! [`raw_args`](Command::raw_args), and [`raw_command`](Session::raw_command) to bypass the

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -178,18 +178,21 @@ impl<'s> Sftp<'s> {
             )));
         };
 
+        // https://github.com/sfackler/shell-escape/issues/5
+        let dir = dir.to_string_lossy();
+
         let test = self
             .session
             .command("test")
-            .arg("'('")
+            .arg("(")
             .arg("-d")
-            .arg(dir)
-            .arg("')'")
+            .arg(&dir)
+            .arg(")")
             .arg("-a")
-            .arg("'('")
+            .arg("(")
             .arg("-w")
-            .arg(dir)
-            .arg("')'")
+            .arg(&dir)
+            .arg(")")
             .output()
             .await?;
 
@@ -199,7 +202,7 @@ impl<'s> Sftp<'s> {
             .session
             .command("test")
             .arg("-e")
-            .arg(dir)
+            .arg(&dir)
             .status()
             .await?
             .success()
@@ -226,6 +229,9 @@ impl<'s> Sftp<'s> {
         path: impl AsRef<std::path::Path>,
     ) -> Result<(), Error> {
         if mode.is_write() {
+            // https://github.com/sfackler/shell-escape/issues/5
+            let path = path.as_ref().to_string_lossy();
+
             // for writes, we want a stronger (and cheaper) test than can()
             // we can't actually use `touch`, since it also works for dirs
             // note that this works b/c stdin is Stdio::null()
@@ -233,7 +239,7 @@ impl<'s> Sftp<'s> {
                 .session
                 .command("cat")
                 .arg(">>")
-                .arg(path.as_ref())
+                .arg(&path)
                 .stdin(Stdio::null())
                 .output()
                 .await?;
@@ -298,6 +304,9 @@ impl<'s> Sftp<'s> {
 
         self.init_op(Mode::Write, path).await?;
 
+        // https://github.com/sfackler/shell-escape/issues/5
+        let path = path.to_string_lossy();
+
         let cat = self
             .session
             .command("tee")
@@ -351,6 +360,9 @@ impl<'s> Sftp<'s> {
 
         self.init_op(Mode::Append, path).await?;
 
+        // https://github.com/sfackler/shell-escape/issues/5
+        let path = path.to_string_lossy();
+
         let cat = self
             .session
             .command("tee")
@@ -403,6 +415,9 @@ impl<'s> Sftp<'s> {
         let path = path.as_ref();
 
         self.init_op(Mode::Read, path).await?;
+
+        // https://github.com/sfackler/shell-escape/issues/5
+        let path = path.to_string_lossy();
 
         let cat = self
             .session

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -238,7 +238,7 @@ impl<'s> Sftp<'s> {
             let touch = self
                 .session
                 .command("cat")
-                .arg(">>")
+                .raw_arg(">>")
                 .arg(&path)
                 .stdin(Stdio::null())
                 .output()

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -388,6 +388,15 @@ async fn escaping() {
 
     let status = dbg!(session
         .command("printf")
+        .args(vec!["%d %d", "1", "2"])
+        .output()
+        .await
+        .unwrap())
+    .status;
+    assert!(status.success());
+
+    let status = dbg!(session
+        .command("printf")
         .arg("%d %d")
         .raw_arg("1 2")
         .output()

--- a/tests/openssh.rs
+++ b/tests/openssh.rs
@@ -35,7 +35,7 @@ async fn stdout() {
     let child = session
         .command("echo")
         .arg("foo")
-        .arg(">")
+        .raw_arg(">")
         .arg("/dev/stderr")
         .output()
         .await
@@ -91,7 +91,7 @@ async fn stderr() {
     let child = session
         .command("echo")
         .arg("foo")
-        .arg(">")
+        .raw_arg(">")
         .arg("/dev/stderr")
         .output()
         .await
@@ -462,7 +462,12 @@ async fn broken_connection() {
     let sleeping = session.command("sleep").arg("1000").spawn().unwrap();
 
     // get ID of remote ssh process
-    let ppid = session.command("echo").arg("$PPID").output().await.unwrap();
+    let ppid = session
+        .command("echo")
+        .raw_arg("$PPID")
+        .output()
+        .await
+        .unwrap();
     eprintln!("ppid: {:?}", ppid);
     let ppid: u32 = String::from_utf8(ppid.stdout)
         .unwrap()


### PR DESCRIPTION
Since that matches `std::process::Command` more closely.
Breaks with weird remote shells, but `raw_` provides an escape hatch.

https://github.com/sfackler/shell-escape/issues/5 is a little sad.