### PR TITLE
Expose the ssh -F option which allows the user to select a custom ssh config file path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,7 @@ shell-escape = "0.1"
 tokio = { version = "1", features = [ "process", "io-util" ] }
 
 [dev-dependencies]
+lazy_static = "1.4.0"
+regex = "1"
 tokio = { version = "1", features = [ "full" ] }
+

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -16,6 +16,7 @@ pub struct SessionBuilder {
     server_alive_interval: Option<u64>,
     known_hosts_check: KnownHosts,
     control_dir: Option<PathBuf>,
+    config_file: Option<PathBuf>,
 }
 
 impl Default for SessionBuilder {
@@ -28,6 +29,7 @@ impl Default for SessionBuilder {
             server_alive_interval: None,
             known_hosts_check: KnownHosts::Add,
             control_dir: None,
+            config_file: None,
         }
     }
 }
@@ -90,6 +92,16 @@ impl SessionBuilder {
     /// If not set, `./` will be used (the current directory).
     pub fn control_directory(&mut self, p: impl AsRef<Path>) -> &mut Self {
         self.control_dir = Some(p.as_ref().to_path_buf());
+        self
+    }
+
+    /// Set an alternative per-user configuration file.
+    ///
+    /// By default, ssh uses `~/.ssh/config`. This is equivalent to `ssh -F <p>`.
+    ///
+    /// Defaults to `None`.
+    pub fn config_file(&mut self, p: impl AsRef<Path>) -> &mut Self {
+        self.config_file = Some(p.as_ref().to_path_buf());
         self
     }
 
@@ -194,6 +206,10 @@ impl SessionBuilder {
             // if the user gives a keyfile, _only_ use that keyfile
             init.arg("-o").arg("IdentitiesOnly=yes");
             init.arg("-i").arg(k);
+        }
+
+        if let Some(ref config_file) = self.config_file {
+            init.arg("-F").arg(config_file);
         }
 
         init.arg(destination);

--- a/src/sftp.rs
+++ b/src/sftp.rs
@@ -480,12 +480,10 @@ impl RemoteFile<'_> {
             } else {
                 io::Error::new(io::ErrorKind::WriteZero, err)
             }
+        } else if err.ends_with(": No such file or directory") {
+            io::Error::new(io::ErrorKind::NotFound, err)
         } else {
-            if err.ends_with(": No such file or directory") {
-                io::Error::new(io::ErrorKind::NotFound, err)
-            } else {
-                io::Error::new(io::ErrorKind::UnexpectedEof, err)
-            }
+            io::Error::new(io::ErrorKind::UnexpectedEof, err)
         }))
     }
 }


### PR DESCRIPTION
I have a use case where I need to use custom ssh config files instead of the users' ~/.ssh/config file in the home directory. This change exposes the ssh -F option as documented here: https://man.openbsd.org/ssh#F. 

Thanks for making this crate and considering my pull request!
Chris. 