### PR TITLE
Bump dep openssh-mux-client to v0.14.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,7 @@ io-lifetimes = "0.5"
 once_cell = "1.8.0"
 dirs = "4.0.0"
 
-openssh-mux-client = { version = "0.14.0", optional = true }
-# needed to make openssh-mux-client compile with -Zminimal-versions
-serde = "1.0.103"
+openssh-mux-client = { version = "0.14.3", optional = true }
 
 [dev-dependencies]
 lazy_static = "1.4.0"


### PR DESCRIPTION
And remove the workaround of dep serde added in #38 

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>